### PR TITLE
[rpc] Define BlockMetadata message and endpoint

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -28,7 +28,13 @@ service AergoRPCService {
   rpc ListBlockHeaders(ListParams) returns (BlockHeaderList) {
   }
 
+  rpc ListBlockMetadata(ListParams) returns (BlockMetadataList) {
+  }
+
   rpc ListBlockStream(Empty) returns (stream Block) {
+  }
+
+  rpc ListBlockMetadataStream(Empty) returns (stream BlockMetadata) {
   }
 
   rpc GetBlock(SingleBytes) returns (Block) {
@@ -162,6 +168,16 @@ message ListParams {
 
 message BlockHeaderList {
   repeated Block blocks = 1;
+}
+
+message BlockMetadata {
+  bytes hash = 1;
+  BlockHeader header = 2;
+  int32 txcount = 3;
+}
+
+message BlockMetadataList {
+  repeated BlockMetadata blocks = 1;
 }
 
 enum CommitStatus {


### PR DESCRIPTION
Currently you can only either get the whole block with body (`GetBlock`, `ListBlockStream`) or blocks with their body stripped (`ListBlockHeaders`). The second method is a bit inconsistent in terms of typing, and also has no way to get the transaction count, which is a necessary feature for e.g. Aergoscan. To fix both at the same time, we introduce a new message type, `BlockMetadata`, and corresponding API.

Note that for backwards compatibility `ListBlockHeaders` is kept as it is, but may be removed after `ListBlockMetadata` has been implemented (it is the same data, just with more consistent typing).