### PR TITLE
[rpc] new methods: GetBlockMetadata, GetBlockBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Development (master)
 ```diff
 + polarrpc.proto
+
 + rpc.proto::Peer::hidden (type: bool, fieldNo: 4)
 - node.proto::PeerAddress::address (type: bytes, fieldNo: 1)
 + node.proto::PeerAddress::address (type: string, fieldNo: 1)
+
 - blockchain.proto::StateProof (type: message)
 + blockchain.proto::AccountProof (type: message)
 - blockchain.proto::ContractVarProof::key (type: string, fieldNo: 3)
@@ -16,6 +18,12 @@
 + blockchain.proto::StateQuery::storageKeys (type: repeated string, fieldNo: 2)
 - rpc.proto::AergoRPCService::GetStateAndProof (arg: AccountAndRoot, ret: StateProof)
 + rpc.proto::AergoRPCService::GetStateAndProof (arg: AccountAndRoot, ret: AccountProof)
+
++ rpc.proto::AergoRPCService::GetBlockMetadata
++ rpc.proto::AergoRPCService::GetBlockBody
++ rpc.proto::PageParams (type: message)
++ rpc.proto::BlockBodyPaged (type: message)
++ rpc.proto::BlockBodyParams (type: message)
 ```
 
 ## 0.9.5 (December 27, 2018)

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -40,8 +40,16 @@ service AergoRPCService {
   rpc ListBlockMetadataStream(Empty) returns (stream BlockMetadata) {
   }
 
-  // Return a single block, queried by hash or number
+  // Return a single block incl. header and body, queried by hash or number
   rpc GetBlock(SingleBytes) returns (Block) {   
+  }
+
+  // Return a single block's metdata (hash, header, and number of transactions), queried by hash or number
+  rpc GetBlockMetadata(SingleBytes) returns (BlockMetadata) {
+  }
+
+  // Return a single block's body, queried by hash or number and list parameters
+  rpc GetBlockBody(BlockBodyParams) returns (BlockBodyPaged) {
   }
 
   // Return a single transaction, queried by transaction hash
@@ -185,6 +193,23 @@ message ListParams {
   uint32 size = 3;
   uint32 offset = 4;
   bool asc = 5;
+}
+
+message PageParams {
+  uint32 offset = 1;
+  uint32 size = 2;
+}
+
+message BlockBodyPaged {
+  uint32 total = 1;
+  uint32 offset = 2;
+  uint32 size = 3;
+  BlockBody body = 4;
+}
+
+message BlockBodyParams {
+  bytes hashornumber = 1;
+  PageParams paging = 2;
 }
 
 message BlockHeaderList {


### PR DESCRIPTION
Currently you can only retrieve a block with all its body, potentially a lot of data.

This adds to new methods, `GetBlockMetadata` (returning hash, header, and number of txs) and `GetBlockBody` (returning the body in a pages fashion).