### PR TITLE
[rpc] Add GetChainInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 + rpc.proto::PageParams (type: message)
 + rpc.proto::BlockBodyPaged (type: message)
 + rpc.proto::BlockBodyParams (type: message)
+
++ rpc.proto::AergoRPCService::GetChainInfo
++ rpc.proto::ChainId (type: message)
++ rpc.proto::ChainInfo (type: message)
 ```
 
 ## 0.9.5 (December 27, 2018)

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -24,6 +24,10 @@ service AergoRPCService {
   rpc Blockchain (Empty) returns (BlockchainStatus) {
   }
 
+  // Returns current blockchain's basic information
+  rpc GetChainInfo (Empty) returns (ChainInfo) {
+  }
+
   // Returns list of Blocks without body according to request
   rpc ListBlockHeaders(ListParams) returns (BlockHeaderList) {
   }
@@ -145,6 +149,23 @@ service AergoRPCService {
 message BlockchainStatus {
   bytes best_block_hash = 1;
   uint64 best_height = 2;
+}
+
+message ChainId {
+  string magic = 1;
+  bool public = 2;
+  bool mainnet = 3;
+  bytes coinbasefee = 4;
+  string consensus = 5;
+}
+
+// ChainInfo returns chain configuration
+message ChainInfo {
+  ChainId chainid = 1;
+  uint32 bpnumber = 2;
+  uint64 maxblocksize = 3;
+  bytes maxtokens = 4;
+  bytes stakingminimum = 5;
 }
 
 message Input {


### PR DESCRIPTION
`ChainId` contains the same information as the genesis config.

`ChainInfo` contains the ChainId and some other configuration variables.

`bpnumber`, e.g. 13
`maxblocksize`, e.g. 1<<20
`maxtokens`, e.g. 500000000000000000000000000
`stakingminimum`, e.g. 1000000000000000000