### PR TITLE
[rpc] add consensus info to blockchain command result

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -157,6 +157,7 @@ service AergoRPCService {
 message BlockchainStatus {
   bytes best_block_hash = 1;
   uint64 best_height = 2;
+  string consensus_info = 3;
 }
 
 message ChainId {


### PR DESCRIPTION
This change modifies the blockchain status message (the result of blockchain RPC command) to show the consensus status information.

For example, the blockchain using DPoS will show the last irreversible block information along with the best block information when blockchain command is run.