### PR TITLE
[RPC] add rpc GetConsensusInfo for raft and other consensus

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -155,6 +155,10 @@ service AergoRPCService {
   // Returns list of event
   rpc ListEvents(FilterInfo) returns (EventList) {
   }
+
+  // Returns status of consensus and bps
+  rpc GetConsensusInfo (Empty) returns (ConsensusInfo) {
+  }
 }
 
 // BlockchainStatus is current status of blockchain
@@ -362,4 +366,11 @@ message PeersParams {
 
 message EventList {
   repeated Event events = 1;
+}
+
+// info and bps is json string
+message ConsensusInfo {
+  string type = 1;
+  string info = 2;
+  repeated string bps = 3;
 }


### PR DESCRIPTION
aergoscan에서 bplist를 보여주는 화면을 제공하기 위해 raft/dpos 등 consensus 특화된 정보를 보여주기 위한 rpc를 추가하려고 합니다.

rpc는 getconsensusinfo 입니다.

raft의 경우 bp 정보, raft leader, raft stat 등의 정보를 보여줄 예정입니다.

