### PR TITLE
[fee] Remove the coinbasefee from ChainID

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -172,8 +172,7 @@ message ChainId {
   string magic = 1;
   bool public = 2;
   bool mainnet = 3;
-  bytes coinbasefee = 4;
-  string consensus = 5;
+  string consensus = 4;
 }
 
 // ChainInfo returns chain configuration


### PR DESCRIPTION
현재, Fixed transaction fee 값을 genesis block 에 넣고 있다.

Fee System 이 들어가면 TX 별로 값이 다르기 때문에 하드 포크에 유연하게 대응하기 위해서 fee package(aergo) 로 관련 코드를 이동한다. 
