### PR TITLE
add reserved fields to the block header

### DIFF
--- a/proto/blockchain.proto
+++ b/proto/blockchain.proto
@@ -21,8 +21,8 @@ message BlockHeader {
   bytes pubKey = 9; // block producer's public key
   bytes coinbaseAccount = 10; // address of account to receive fees
   bytes sign = 11; // block producer's signature of BlockHeader
-  // CAUTION: THE SIGN MUST BE THE LAST FIELD.
-  // DO NOT ADD A NEW FIELD AFTER THE SIGN FIELD.
+  bytes meta0 = 12; // reserved field
+  bytes meta1 = 13; // reserved field
 }
 
 message BlockBody {


### PR DESCRIPTION
Add two byte array fields to the block header for a future use. 