### PR TITLE
change state query key type from string to bytes to query with the trie key directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 + blockchaon.proto::Block::size (type: int64, fieldNo: 4)
 ```
 
+## 
+- blockchain.proto:ContractVarProof::key(type: string fieldNo: 3)
++ blockchain.proto:ContractVarProof::key(type: bytes fieldNo: 9)
+- blockchain.proto:StateQuery::storageKeys(type: repeated string fieldNo: 2)
++ blockchain.proto:ContractVarProof::storageKeys(type: repeated bytes fieldNo: 5)
+
 ## 1.0.0 (April 1, 2019)
 
 ```diff

--- a/proto/blockchain.proto
+++ b/proto/blockchain.proto
@@ -88,12 +88,13 @@ message AccountProof {
 message ContractVarProof{
   bytes value = 1;
   bool inclusion = 2;
-  string key = 3;
+  reserved 3;
   bytes proofKey = 4;
   bytes proofVal = 5;
   bytes bitmap = 6;
   uint32 height = 7;
   repeated bytes auditPath = 8;
+  bytes key = 9;
 }
 
 message StateQueryProof {
@@ -161,9 +162,10 @@ message Query {
 
 message StateQuery {
   bytes contractAddress = 1;
-  repeated string storageKeys = 2;
+  reserved 2;
   bytes root = 3;
   bool compressed = 4;
+  repeated bytes storageKeys = 5;
 }
 
 message FilterInfo {


### PR DESCRIPTION
In order to support state queries of keys like `key = string.char(0x01)` in 
```lua
system.setItem(string.char(0x01), 'value')
```
we need support for trie key bytes directly instead of the usual string keys like `"_sv_mapName-key"`