### PR TITLE
Add import and export as keystore

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -121,8 +121,12 @@ service AergoRPCService {
   rpc ImportAccount(ImportFormat) returns (Account) {
   }
 
-  // Export account stored in this node
+  // Export account stored in this node as wif format
   rpc ExportAccount(Personal) returns (SingleBytes) {
+  }
+
+  // Export account stored in this node as keystore format
+  rpc ExportAccountKeystore(Personal) returns (SingleBytes) {
   }
 
   // Query a contract method
@@ -353,6 +357,7 @@ message ImportFormat{
   SingleBytes wif = 1;
   string oldpass = 2;
   string newpass = 3;
+  SingleBytes keystore = 4;
 }
 
 message Staking {


### PR DESCRIPTION
Related: https://github.com/aergoio/aergo/pull/114

- `ImportAccount`: `ImportFormat` has a new parameter `Keystore`. The endpoint selects the method based on existence of either the Wif or the Keystore parameter in the protobuffer msg.
- `ExportAccountKeystore` (new)
- `ExportAccount` (unchanged)