### PR TITLE
new types for deploy and redeploy

### DIFF
--- a/proto/blockchain.proto
+++ b/proto/blockchain.proto
@@ -43,6 +43,8 @@ enum TxType {
   CALL = 5;
   DEPLOY = 6;
   MULTICALL = 7;
+  DEPLOY2 = 8;
+  REDEPLOY2 = 9;
 }
 
 message Tx {

--- a/proto/blockchain.proto
+++ b/proto/blockchain.proto
@@ -42,6 +42,7 @@ enum TxType {
   TRANSFER = 4;
   CALL = 5;
   DEPLOY = 6;
+  MULTICALL = 7;
 }
 
 message Tx {


### PR DESCRIPTION
The number 7 is reserved for `MULTICALL`

The `DEPLOY` and `REDEPLOY` transactions will become legacy and will be rejected in a new hardfork

Maybe they can be renamed to something like `LEGACY_DEPLOY` or `OLD_DEPLOY`